### PR TITLE
Drop bson

### DIFF
--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -23,7 +23,7 @@ from fuse import Operations, LoggingMixIn, FuseOSError
 import requests
 import datetime
 import threading
-from bson import objectid
+import uuid
 from queue import Queue
 import traceback
 
@@ -430,7 +430,7 @@ class WtDmsGirderFS(GirderFS):
 
     def _make_dict(self, name, id=None):
         if id is None:
-            id = objectid.ObjectId()
+            id = uuid.uuid1()
         return {'obj': {'_id': id, 'name': name, 'created': self.ctime},
                 'listing': {'folders': [], 'files': []},
                 'dirmap': {}}

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 install_requires = ['fusepy', 'girder-client', 'requests', 'python-dateutil',
-                    'six', 'bson']
+                    'six']
 if sys.version_info[0] == 2:
     install_requires.append('pathlib')
     install_requires.append('backports.datetime_timestamp')


### PR DESCRIPTION
We don't need `bson` for internal caching.