### PR TITLE
Versioning FS

### DIFF
--- a/girderfs/__init__.py
+++ b/girderfs/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.8.0rc3'
+__version__ = '0.8.0'
 __author__ = 'Kacper Kowalik'

--- a/girderfs/__init__.py
+++ b/girderfs/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.8.0'
+__version__ = '0.9.0rc1'
 __author__ = 'Kacper Kowalik'

--- a/girderfs/__init__.py
+++ b/girderfs/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.8.0rc1'
+__version__ = '0.8.0rc2'
 __author__ = 'Kacper Kowalik'

--- a/girderfs/__init__.py
+++ b/girderfs/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.8.0dev0'
+__version__ = '0.8.0rc1'
 __author__ = 'Kacper Kowalik'

--- a/girderfs/__init__.py
+++ b/girderfs/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.8.0rc2'
+__version__ = '0.8.0rc3'
 __author__ = 'Kacper Kowalik'

--- a/girderfs/__init__.py
+++ b/girderfs/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.7.0'
+__version__ = '0.8.0dev0'
 __author__ = 'Kacper Kowalik'

--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -1266,7 +1266,7 @@ class WtVersionsFS(WtDmsGirderFS):
     def _load_object(self, id: str, model: str, path: pathlib.Path):
         if id == self.root_id:
             versions_folder = self.girder_cli.get(
-                f"{self._resource_name}/getRoot", parameters={"taleId": self.tale_id}
+                f"{self._resource_name}/root", parameters={"taleId": self.tale_id}
             )
             self.root_id = str(versions_folder['_id'])
             return self._add_model('folder', versions_folder)
@@ -1276,7 +1276,7 @@ class WtVersionsFS(WtDmsGirderFS):
     def _girder_get_listing(self, obj: dict, path: pathlib.Path):
         if str(obj['_id']) == self.root_id:
             return {
-                'folders': self.girder_cli.get('%s/list?rootId=%s' %
+                'folders': self.girder_cli.get('%s?rootId=%s' %
                                                (self._resource_name, self.root_id)),
                 'files': []
             }
@@ -1343,7 +1343,7 @@ class WtVersionsFS(WtDmsGirderFS):
             # but reasonable design dictates that we eventually do expose it.
             self.girder_cli.delete('%s/%s' % (self._resource_name, obj['_id']))
         else:
-            self.girder_cli.get('%s/%s/rename' % (self._resource_name, obj['_id']),
+            self.girder_cli.put('%s/%s' % (self._resource_name, obj['_id']),
                                 {'newName': new.parts[-1]})
 
     def _get_perm(self, path, is_dir):

--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -1252,11 +1252,11 @@ def _path_from_id(object_id):
 
 class WtVersionsFS(WtDmsGirderFS):
 
-    def __init__(self, instance_id, gc):
-        self.instance_id = instance_id
-        WtDmsGirderFS.__init__(self, instance_id, gc,
+    def __init__(self, tale_id, gc):
+        self.tale_id = tale_id
+        WtDmsGirderFS.__init__(self, tale_id, gc,
                                default_file_perm=0o444, default_dir_perm=0o555)
-        self.session_id = _getSessionIdFromInstanceId(instance_id, gc)
+        self.session_id = None  # TODO: fixme
         self.cached_versions = {}
 
     @property
@@ -1265,8 +1265,9 @@ class WtVersionsFS(WtDmsGirderFS):
 
     def _load_object(self, id: str, model: str, path: pathlib.Path):
         if id == self.root_id:
-            versions_folder = self.girder_cli.get('%s/getRoot?instanceId=%s' %
-                                                  (self._resource_name, self.instance_id))
+            versions_folder = self.girder_cli.get(
+                f"{self._resource_name}/getRoot", parameters={"taleId": self.tale_id}
+            )
             self.root_id = str(versions_folder['_id'])
             return self._add_model('folder', versions_folder)
         else:
@@ -1643,8 +1644,8 @@ class CacheFile:
 
 class WtRunsFS(WtVersionsFS):
 
-    def __init__(self, instance_id, gc, versions_mountpoint):
-        WtVersionsFS.__init__(self, instance_id, gc)
+    def __init__(self, tale_id, gc, versions_mountpoint):
+        WtVersionsFS.__init__(self, tale_id, gc)
         versions_path = pathlib.Path(versions_mountpoint)
         if not versions_path.is_absolute():
             # we'll use this from Runs/<run>/, so move this up a bit

--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -555,7 +555,7 @@ class WtDmsGirderFS(GirderFS):
         # mount points can have arbitrary depth, so pre-populate the cache with
         # the necessary directory structure
         for entry in dataSet:
-            self._add_session_entry(self.sessionId, entry)
+            self._add_session_entry(self.root_id, entry)
 
     def _fake_obj(self, fs_type: str, name=None, id=None, ctime=None):
         if ctime is None:


### PR DESCRIPTION
This PR adds versions and runs filesystem support. In doing so, it cleans up and modifies the base classes that the respective implementations inherit from, particularly GirderFS and WtDmsGirderFS. Some of the changes include:

* added the concept of mutable directories (whose metadata and listings can change) and files (whose contents/metadata can change)
* added code to refresh cached objects when they are mutable and have changed
* simplified the caching a bit: the cache used to map object ids to listings, which then contained full Girder objects. The way to retrieve a Girder object from the cache using an id was by looking at the listing for the parent id and iterating through the listing and finding the object with the matching id. This is now changed such that the cache stores a mapping between ids and a CacheEntry, the latter being a structure containing the Girder Object, a listing of the form Dict[<name>, CacheEntry] and some miscellaneous fields.
* added some more typechecking