### PR TITLE
Update listdirinfo wrt to recent changes in caching/listing objects

### DIFF
--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -347,30 +347,10 @@ class GirderFS(LoggingMixIn, Operations):
         '''
 
         logger.debug("-> listdirinfo({})".format(path))
-
-        def _get_stat(obj):
-            ctime = _convert_time(obj["created"])
-            try:
-                mtime = _convert_time(obj["updated"])
-            except KeyError:
-                mtime = ctime
-            return dict(st_ctime=ctime, st_mtime=mtime,
-                        st_size=obj["size"], st_atime=time.time())
-
-        listdir = []
-        raw_listing = self._get_listing_by_path(path)
-
-        for obj in raw_listing['files']:
-            stat = dict(st_mode=(S_IFREG | self.default_file_perm), st_nlink=1)
-            stat.update(_get_stat(obj))
-            listdir.append((obj['name'], stat))
-
-        for obj in raw_listing['folders']:
-            stat = dict(st_mode=(S_IFDIR | self.default_dir_perm), st_nlink=2)
-            stat.update(_get_stat(obj))
-            listdir.append((obj['name'], stat))
-
-        return listdir
+        return [
+            (name, self.getattr(os.path.join(path, name)))
+            for name in self._get_listing_by_path(path).keys()
+        ]
 
     def isdir(self, path):
         '''Pyfilesystem essential method'''


### PR DESCRIPTION
During investigation of [test failures](https://app.circleci.com/pipelines/github/whole-tale/girder_wholetale/101/workflows/42654264-5cbe-484a-b52b-bad5779e7e67/jobs/1387) for wholetale plugin it turned out that `listdirinfo` is completely broken due to #13, which in turn broke binder imports. This PR updates `listdirinfo` to take into account that format of raw data listing was totally changed.

### How to test?
The easiest way is via import binder (e.g. https://sandbox.zenodo.org/record/714878) with `asTale == True`
