### PR TITLE
[WtDms] getting objs for root_id requires dedicated endpoint. Fixes #23

### DIFF
--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -67,13 +67,13 @@ class DictCache(dict):
 class CacheEntry:
     def __init__(self, obj: dict, listing: dict = None, pinned=False):
         self.obj = obj
+        if listing is None:
+            listing = {}
         self.listing = listing
         self.loadTime = time.time()
         self.pinned = pinned
 
     def add_to_listing(self, entry: 'CacheEntry'):
-        if self.listing is None:
-            self.listing = {}
         self.listing[entry.obj['name']] = entry
 
     def __str__(self):

--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -551,6 +551,11 @@ class WtDmsGirderFS(GirderFS):
         for entry in dataSet:
             self._add_session_entry(self.root_id, entry)
 
+    def _girder_get_listing(self, obj: dict, path: pathlib.Path):
+        if obj["_id"] == self.root_id:
+            return self.girder_cli.get('dm/session/%s?loadObjects=true' % self.root_id)
+        return super()._girder_get_listing(obj, path)
+
     def _fake_obj(self, fs_type: str, name=None, id=None, ctime=None):
         if ctime is None:
             ctime = self.ctime


### PR DESCRIPTION
We were calling `GET /dm/fs/:id/listing` for root id (which is a Session object). This change adds a special handling for root to WtDMS.