### PR TITLE
Fix various dms fs issues

### DIFF
--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -531,9 +531,9 @@ class WtDmsGirderFS(GirderFS):
         self.openFiles = {}
         self.locks = {}
         self.fobjs = {}
-        self.ctime = int(time.time())
 
     def _init_cache(self):
+        self.ctime = time.ctime(time.time())
         self.cache = CacheWrapper(DictCache())
 
     def _load_object(self, id: str, model: str, path: pathlib.Path):

--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -581,8 +581,12 @@ class WtDmsGirderFS(GirderFS):
             return entry
         crt = path[0]
 
-        obj = self._fake_obj(fs_type='folder', name=crt)
-        subEntry = CacheEntry(obj)
+        if entry.listing and crt in entry.listing:
+            subEntry = entry.listing[crt]
+            obj = subEntry.obj
+        else:
+            obj = self._fake_obj(fs_type='folder', name=crt)
+            subEntry = CacheEntry(obj)
         entry.add_to_listing(subEntry)
         self.cache[str(obj['_id'])] = subEntry
 

--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -539,7 +539,7 @@ class WtDmsGirderFS(GirderFS):
     def _load_object(self, id: str, model: str, path: pathlib.Path):
         if id == self.root_id:
             root = self.girder_cli.get('dm/session/%s?loadObjects=true' % self.root_id)
-            self.cache[id] = CacheEntry(root)
+            self.cache[id] = CacheEntry(root, listing={})
             self._populate_mount_points(root['dataSet'])
             return self._add_model('folder', root)
         else:

--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -551,12 +551,12 @@ class WtDmsGirderFS(GirderFS):
         for entry in dataSet:
             self._add_session_entry(self.root_id, entry)
 
-    def _fake_obj(self, fs_type: str, name=None, id=None, ctime=None):
+    def _fake_obj(self, fs_type: str, name=None, id=None, ctime=None, size=0):
         if ctime is None:
             ctime = self.ctime
         if id is None:
             id = uuid.uuid1()
-        return {'_id': id, 'name': name, 'created': ctime}
+        return {'_id': id, 'name': name, 'created': ctime, '_modelType': fs_type, 'size': size}
 
     def _add_session_entry(self, id: str, dse, prefix: List[str] = None):
         if logger.isEnabledFor(logging.DEBUG):


### PR DESCRIPTION
There were a number of issues that prevented mountpoints not in the root directory from working. These are fixed by commits 
680c149, e76b8d5, and 7b2cab0.

There was an additional issue which got triggered when the data set was empty: the root directory did not have a listing initialized; that, in turn, triggered a lookup which ran into (some of) the above problems. Commit 7c15756 adds an empty listing for the root directory.

This PR fixes #23 and is an alternative to #24 *with respect to the empty data set issue* (aka, #24, an otherwise wonderful PR, is insufficient in addressing non-root mountpoint issues).

I have tested this with both empty datasets and something of the sort:

```json
"dataSet" : [ 
        {
            "itemId" : "5e48743c2d022856c3a6cd00",
            "_modelType" : "item",
            "mountPath" : "/a/b/BBH_events_v3.json"
        }, 
        {
            "itemId" : "5e48743e2d022856c3a6cd14",
            "_modelType" : "item",
            "mountPath" : "/c/d/L-L1_LOSC_4_V1-1167559920-32.hdf5"
        }, 
        {
            "itemId" : "5e48743d2d022856c3a6cd0b",
            "_modelType" : "item",
            "mountPath" : "/a/e/H-H1_LOSC_4_V1-1167559920-32.hdf5"
        }, 
        {
            "itemId" : "5e48743d2d022856c3a6cd0d",
            "_modelType" : "item",
            "mountPath" : "H-H1_LOSC_4_V2-1126259446-32.hdf5"
        }, 
...
```

Your object IDs may vary.