### PR TITLE
Raise EPERM if dms failed with 403

### DIFF
--- a/girderfs/dms.py
+++ b/girderfs/dms.py
@@ -1,13 +1,14 @@
 import logging
 import os
 import pathlib
+import re
 import sys
 import tempfile
 import threading
 import time
 import traceback
 import uuid
-from errno import EIO
+from errno import EIO, EPERM
 from typing import List
 
 import requests
@@ -256,6 +257,8 @@ class WtDmsGirderFS(GirderFS):
 
             try:
                 if obj["dm"]["transferError"]:
+                    if re.match("^40[13] Client Error:", obj["dm"]["transferErrorMessage"]):
+                        raise FuseOSError(EPERM)
                     raise OSError(EIO, os.strerror(EIO))
             except KeyError:
                 pass


### PR DESCRIPTION
For details see https://github.com/whole-tale/girder_wholetale/pull/465#issuecomment-943396208. How to test is also covered there.

tl;dr If dms raises 403 during file transfer you should get:

```
$ head wtdmawf530ti 
head: error reading 'wtdmawf530ti': Operation not permitted
```

instead of generic `Input/output error`.