### PR TITLE
Only consider written bytes for lock if we expect them to exists. 

### DIFF
--- a/girderfs/dms.py
+++ b/girderfs/dms.py
@@ -271,7 +271,8 @@ class WtDmsGirderFS(GirderFS):
         while True:
             if fdict["downloaded"]:
                 return
-            if fdict["written"] >= offset + size:
+            limit = offset + size
+            if limit > 0 and fdict["written"] >= limit:
                 return
             time.sleep(0.1)
 


### PR DESCRIPTION
A necessary part for https://github.com/whole-tale/girder_wholetale/issues/544