### PR TITLE
fix: always defined cache and cachedir. Fixes #36

### DIFF
--- a/girderfs/core.py
+++ b/girderfs/core.py
@@ -30,6 +30,9 @@ class GirderFS(LoggingMixIn, Operations):
     :type girder_cli: girder_client.GriderClient
     """
 
+    _cachedir = None
+    _cache = None
+
     def __init__(
         self,
         root_id,
@@ -45,12 +48,19 @@ class GirderFS(LoggingMixIn, Operations):
         self.fd = 0
         self.default_file_perm = default_file_perm
         self.default_dir_perm = default_dir_perm
-        self._init_cache()
         self.root = self._load_object(self.root_id, root_model, None)
 
-    def _init_cache(self):
-        self.cachedir = tempfile.mkdtemp(prefix="wtdm")
-        self.cache = CacheWrapper(diskcache.Cache(self.cachedir))
+    @property
+    def cachedir(self):
+        if not self._cachedir:
+            self._cachedir = tempfile.mkdtemp(prefix="wtdm")
+        return self._cachedir
+
+    @property
+    def cache(self):
+        if self._cache is None:
+            self._cache = CacheWrapper(diskcache.Cache(self.cachedir))
+        return self._cache
 
     def _load_object(self, id: str, model: str, path: pathlib.Path):
         if model is None and id == self.root_id:

--- a/girderfs/dms.py
+++ b/girderfs/dms.py
@@ -104,8 +104,7 @@ class WtDmsGirderFS(GirderFS):
     """
 
     def __init__(self, sessionId, gc, default_file_perm=0o644, default_dir_perm=0o755):
-        GirderFS.__init__(
-            self,
+        super().__init__(
             str(sessionId),
             gc,
             root_model="session",
@@ -369,8 +368,6 @@ class WtDmsGirderFS(GirderFS):
         self.girder_cli.delete("dm/lock/%s" % (lockId))
 
     def destroy(self, private_data):
-        GirderFS.destroy(self, private_data)
-
         for path in list(self.openFiles.keys()):
             fdict = self.openFiles[path]
             try:
@@ -382,6 +379,8 @@ class WtDmsGirderFS(GirderFS):
                     logger.debug("-> destroy: no physical path for {}".format(path))
             except Exception:
                 pass
+        super().destroy(private_data)
+
 
     def release(self, path, fh):  # pylint: disable=unused-argument
         logger.debug("-> release({}, {})".format(path, fh))

--- a/girderfs/dms.py
+++ b/girderfs/dms.py
@@ -117,12 +117,16 @@ class WtDmsGirderFS(GirderFS):
         self.openFiles = {}
         self.locks = {}
         self.fobjs = {}
+        self.ctime = time.ctime(time.time())
         # call _girder_get_listing to pre-populate cache with mount point structure
         self._girder_get_listing(self.root, None)
 
-    def _init_cache(self):
-        self.ctime = time.ctime(time.time())
-        self.cache = CacheWrapper()
+    @property
+    def cache(self):
+        """This cache is for requests only. DownloadThread has its own for files."""
+        if self._cache is None:
+            self._cache = CacheWrapper()
+        return self._cache
 
     def _load_object(self, id: str, model: str, path: pathlib.Path):
         if id == self.root_id:


### PR DESCRIPTION
For reasons beyond my comprehension, `self._init_cache()` was not properly called during `__init__`. I really don't know why.   As result `WtDmsGirderFS.cachedir` was undefined. I scrapped it and replaced it with properties.