### PR TITLE
Expose GirderFS via HTTP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.10-slim-bullseye
+
+RUN apt -qqy update \
+  && apt install --no-install-recommends -qqy \ 
+    fuse3 \
+    davfs2 \
+    libfuse2 \
+    libcurl4 \
+    libjansson4 \
+    tini \
+    sudo \
+  && apt install --no-install-recommends -qqy \
+    libjansson-dev \
+    libfuse3-dev \
+    libcurl4-openssl-dev \
+    git \
+    pkg-config \
+    build-essential \
+  && git clone https://github.com/data-exp-lab/girderfs_passthrough.git /tmp/passthrough \
+  && cd /tmp/passthrough \
+  && make \
+  && make install \
+  && cd / \
+  && rm -rf /tmp/passthrough \
+  && apt remove -qqy \
+    libjansson-dev \
+    libcurl4-openssl-dev \
+    git \
+    pkg-config \
+    build-essential \
+  && apt autoremove -qqy \
+  && apt -qqy clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && echo "user_allow_other" >> /etc/fuse.conf
+
+COPY . /app
+WORKDIR /app
+
+RUN pip install --no-cache-dir . && pip install tornado jsonschema --no-cache-dir
+ENTRYPOINT ["/usr/bin/tini", "--", "girderfs-server"]

--- a/girderfs/schemas.py
+++ b/girderfs/schemas.py
@@ -1,0 +1,228 @@
+import json
+
+import jsonschema
+import requests
+
+
+class MountTypes:
+    data = "data"
+    home = "home"
+    workspace = "workspace"
+    run = "run"
+    runs = "runs"
+    versions = "versions"
+
+
+class MountProtocols:
+    bind = "bind"
+    girderfs = "girderfs"
+    passthrough = "passthrough"
+    webdav = "webdav"
+
+
+class MountValidator:
+    def __init__(self, data):
+        self.data = data
+
+    def validate(self):
+        jsonschema.validate(self.data, mountsSchema)
+        for mount in self.data["mounts"]:
+            if mount["type"] == MountTypes.data:
+                if mount["protocol"] not in [
+                    MountProtocols.girderfs,
+                    MountProtocols.passthrough,
+                ]:
+                    raise ValueError(
+                        f"Invalid protocol for {MountTypes.data} mount: {mount['protocol']}"
+                    )
+            elif mount["type"] == MountTypes.home:
+                if mount["protocol"] not in [
+                    MountProtocols.bind,
+                    MountProtocols.webdav,
+                ]:
+                    raise ValueError(
+                        f"Invalid protocol for {MountTypes.home} mount: {mount['protocol']}"
+                    )
+            elif mount["type"] == MountTypes.workspace:
+                if mount["protocol"] not in [
+                    MountProtocols.bind,
+                    MountProtocols.webdav,
+                ]:
+                    raise ValueError(
+                        f"Invalid protocol for {MountTypes.workspace} mount: {mount['protocol']}"
+                    )
+            elif mount["type"] == MountTypes.run:
+                if mount["protocol"] not in [
+                    MountProtocols.bind,
+                    MountProtocols.webdav,
+                ]:
+                    raise ValueError(
+                        f"Invalid protocol for {MountTypes.run} mount: {mount['protocol']}"
+                    )
+            elif mount["type"] == MountTypes.runs:
+                if mount["protocol"] not in [MountProtocols.girderfs]:
+                    raise ValueError(
+                        f"Invalid protocol for {MountTypes.runs} mount: {mount['protocol']}"
+                    )
+            elif mount["type"] == MountTypes.versions:
+                if mount["protocol"] not in [MountProtocols.girderfs]:
+                    raise ValueError(
+                        f"Invalid protocol for {MountTypes.versions} mount: {mount['protocol']}"
+                    )
+            else:
+                raise ValueError(f"Invalid mount type: {mount['type']}")
+
+
+mountSchema = {
+    "title": "mount",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "A schema representing a single Whole Tale FUSE mount type",
+    "type": "object",
+    "properties": {
+        "type": {
+            "description": "The type of mount",
+            "type": "string",
+            "enum": [
+                MountTypes.data,
+                MountTypes.home,
+                MountTypes.workspace,
+                MountTypes.run,
+                MountTypes.runs,
+                MountTypes.versions,
+            ],
+        },
+        "protocol": {
+            "description": "The protocol to use for the mount",
+            "type": "string",
+            "enum": [
+                MountProtocols.bind,
+                MountProtocols.girderfs,
+                MountProtocols.passthrough,
+                MountProtocols.webdav,
+            ],
+        },
+        "location": {
+            "description": (
+                "The location of the mount relative to the root of the mounts collection"
+            ),
+            "type": "string",
+        },
+    },
+    "required": ["type", "protocol", "location"],
+    "additionalProperties": False,
+}
+
+mountsSchema = {
+    "title": "mounts",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "A schema representing a collection of Whole Tale FUSE mounts",
+    "type": "object",
+    "properties": {
+        "mounts": {
+            "description": "A collection of mounts",
+            "type": "array",
+            "items": mountSchema,
+        },
+        "girderApiUrl": {
+            "description": "The url of the girder api",
+            "type": "string",
+        },
+        "girderApiKey": {
+            "description": "The api key for the girder api",
+            "type": "string",
+        },
+        "root": {
+            "description": "The root of the mounts collection",
+            "type": "string",
+        },
+        "taleId": {
+            "description": (
+                "The id of the Tale. Required for workspace, versions, and runs mounts "
+                "and optional for data mount."
+            ),
+            "type": "string",
+        },
+        "userId": {
+            "description": (
+                "The id of the user. Required for home mount. If not provided, the user "
+                "will be derived using girderApiKey."
+            ),
+            "type": "string",
+        },
+        "runId": {
+            "description": "The id of the run. Required for run mount.",
+            "type": "string",
+        },
+        "sessionId": {
+            "description": (
+                "The id of the session. Required for data mount. If not provided, "
+                "the session will be created from Tale's dataSet."
+            ),
+            "type": "string",
+        },
+    },
+    "required": ["mounts", "girderApiUrl", "girderApiKey", "root"],
+    "additionalProperties": False,
+}
+
+# Write example curl POST utilizing mountsSchema
+# Path: mounts_example.py
+
+if __name__ == "__main__":
+    mounts = {
+        "mounts": [
+            {
+                "type": "data",
+                "protocol": "girderfs",
+                "location": "/mnt/girderfs",
+                "girderObject": {
+                    "_modelType": "folder",
+                    "_id": "5d9b1b9b2f4a9c0001e9b1a6",
+                },
+            },
+            {
+                "type": "home",
+                "protocol": "bind",
+                "location": "/mnt/home",
+                "girderObject": {
+                    "_modelType": "user",
+                    "_id": "5d9b1b9b2f4a9c0001e9b1a6",
+                },
+            },
+            {
+                "type": "workspace",
+                "protocol": "bind",
+                "location": "/mnt/workspace",
+                "girderObject": {
+                    "_modelType": "tale",
+                    "_id": "5d9b1b9b2f4a9c0001e9b1a6",
+                },
+            },
+            {
+                "type": "runs",
+                "protocol": "bind",
+                "location": "/mnt/runs",
+                "girderObject": {
+                    "_modelType": "tale",
+                    "_id": "5d9b1b9b2f4a9c0001e9b1a6",
+                },
+            },
+            {
+                "type": "versions",
+                "protocol": "bind",
+                "location": "/mnt/versions",
+                "girderObject": {
+                    "_modelType": "tale",
+                    "_id": "5d9b1b9b2f4a9c0001e9b1a6",
+                },
+            },
+        ],
+        "girderApiUrl": "https://girder.dandiarchive.org/api/v1",
+        "girderApiKey": "5d9b1b9b2f4a9c0001e9b1a6",
+    }
+    response = requests.post(
+        "http://localhost:8888/",
+        data=json.dumps(mounts),
+        headers={"Content-Type": "application/json"},
+    )
+    print(response.text)

--- a/girderfs/server.py
+++ b/girderfs/server.py
@@ -93,8 +93,6 @@ class MainHandler(tornado.web.RequestHandler):
                 cmd = cmd.format(**args)
             elif mount["protocol"] == MountProtocols.girderfs:
                 gcObj, fs_type = self.mounttype_to_fs(mount["type"])
-                if not gcObj:
-                    continue
                 cmd = (
                     f"girderfs -c {fs_type} "
                     f"--api-url {self.state['girderApiUrl']} "
@@ -164,8 +162,6 @@ class MainHandler(tornado.web.RequestHandler):
                     )
                 else:
                     dataset = self.state["tale"]["dataSet"]
-                if not dataset:
-                    return None, None
                 self.state["session"] = self.gc.post(
                     "dm/session", parameters={"dataSet": json.dumps(dataset)}
                 )

--- a/girderfs/server.py
+++ b/girderfs/server.py
@@ -1,0 +1,186 @@
+# Basic tornado server that handles POST and DELETE requests
+import json
+import os
+import subprocess
+
+import jsonschema
+import tornado.httpclient
+import tornado.httpserver
+import tornado.ioloop
+import tornado.options
+import tornado.web
+from girder_client import GirderClient
+from tornado.options import define, options
+
+from .schemas import MountProtocols, MountTypes, MountValidator
+
+define("port", default=8888, help="run on the given port", type=int)
+
+
+mount = {}
+
+
+class MainHandler(tornado.web.RequestHandler):
+    _gc = None
+
+    def initialize(self, state):
+        self.state = state
+
+    def post(self):
+        try:
+            data = tornado.escape.json_decode(self.request.body)
+            MountValidator(data).validate()
+        except jsonschema.exceptions.ValidationError as e:
+            self.set_status(400)
+            self.write(e.message)
+            return
+        except ValueError as e:
+            self.set_status(400)
+            self.write(e.message)
+            return
+        self.state.update(data)
+        self.state["root"] = os.path.join(
+            os.environ["WT_VOLUMES_PATH"], "mountpoints", data["root"]
+        )
+        if not os.path.exists(self.state["root"]):
+            os.makedirs(self.state["root"])
+        self.get_girder_objects()
+        self.execute()
+
+    @property
+    def gc(self):
+        if self._gc is None:
+            self._gc = GirderClient(apiUrl=self.state["girderApiUrl"])
+            self._gc.authenticate(apiKey=self.state["girderApiKey"])
+        return self._gc
+
+    def get_girder_objects(self):
+        if "taleId" in self.state:
+            self.state["tale"] = self.gc.get(f"/tale/{self.state['taleId']}")
+        if "userId" in self.state:
+            self.state["user"] = self.gc.get(f"/user/{self.state['userId']}")
+        else:
+            self.state["user"] = self.gc.get("/user/me")
+        if "runId" in self.state:
+            self.state["run"] = self.gc.get(f"/run/{self.state['runId']}")
+            if "tale" not in self.state:
+                runs_root = self.gc.get(f"/folder/{self.state['run']['parentId']}")
+                self.state["tale"] = self.gc.get(f"/tale/{runs_root['meta']['taleId']}")
+            self.state["run"]["taleId"] = self.state["tale"]["_id"]
+        if "sessionId" in self.state:
+            self.state["session"] = self.gc.get(
+                f"/dm/session/{self.state['sessionId']}"
+            )
+
+    def execute(self):
+        for mount in self.state["mounts"]:
+            destination = os.path.join(self.state["root"], mount["location"])
+            if not os.path.exists(destination):
+                os.makedirs(destination)
+
+            if mount["protocol"] == MountProtocols.webdav:
+                girder_url = self.gc.urlBase.replace("api/v1", "").rstrip("/")
+                args = {
+                    "user": self.state["user"]["login"],
+                    "pass": "token:{}".format(self.gc.token),
+                    "destination": destination,
+                    "opts": "-o uid=1000,gid=100,file_mode=0600,dir_mode=2700",
+                    "source": girder_url + self.webdav_url(mount["type"]),
+                }
+                cmd = (
+                    'echo "{user}\n{pass}" | mount.davfs {opts} {source} {destination}'
+                )
+                cmd = cmd.format(**args)
+            elif mount["protocol"] == MountProtocols.girderfs:
+                gcObj, fs_type = self.mounttype_to_fs(mount["type"])
+                if not gcObj:
+                    continue
+                cmd = (
+                    f"girderfs -c {fs_type} "
+                    f"--api-url {self.state['girderApiUrl']} "
+                    f"--api-key {self.state['girderApiKey']} "
+                    f"{destination} {gcObj['_id']}"
+                )
+            elif mount["protocol"] == MountProtocols.bind:
+                source = os.path.join(
+                    os.environ["WT_VOLUMES_PATH"], self.source_path_bind(mount["type"])
+                )
+                cmd = f"sudo mount --bind {source} {destination}"
+            elif mount["protocol"] == MountProtocols.passthrough:
+                cmd = (
+                    "passthrough-fuse -o allow_other "
+                    f"--girder-url={self.state['girderApiUrl']}/folder/{gcObj['_id']}/listing "
+                    f"--token={self.gc.token} {destination}"
+                )
+
+            subprocess.check_output(cmd, shell=True)
+
+    def delete(self):
+        for mount in self.state["mounts"]:
+            destination = os.path.join(self.state["root"], mount["location"])
+            if mount["protocol"] == MountProtocols.webdav:
+                cmd = f"umount {destination}"
+            elif mount["protocol"] == MountProtocols.girderfs:
+                cmd = f"fusermount -u {destination}"
+            elif mount["protocol"] == MountProtocols.bind:
+                cmd = f"sudo umount {destination}"
+            elif mount["protocol"] == MountProtocols.passthrough:
+                cmd = f"sudo umount {destination}"
+            subprocess.check_output(cmd, shell=True)
+            os.rmdir(destination)
+        os.rmdir(self.state["root"])
+        if self.state.get("session"):
+            self.gc.delete(f"dm/session/{self.state['session']['_id']}")
+        self.state.clear()
+
+    def source_path_bind(self, mount_type):
+        if mount_type == MountTypes.home:
+            login = self.state["user"]["login"]
+            return f"homes/{login[0]}/{login}"
+        elif mount_type == MountTypes.run:
+            run = self.state["run"]
+            return f"runs/{run['taleId'][0:2]}/{run['taleId']}/{run['_id']}/workspace"
+        elif mount_type == MountTypes.workspace:
+            tale = self.state["tale"]
+            return f"workspaces/{tale['_id'][0]}/{tale['_id']}"
+
+    def webdav_url(self, mount_type):
+        if mount_type == MountTypes.home:
+            return f"/homes/{self.state['user']['_id']}"
+        elif mount_type == MountTypes.run:
+            return f"/runs/{self.state['run']['_id']}"
+        elif mount_type == MountTypes.workspace:
+            return f"/tales/{self.state['tale']['_id']}"
+
+    def mounttype_to_fs(self, mount_type):
+        if mount_type == MountTypes.versions:
+            return self.state["tale"], "wt_versions"
+        elif mount_type == MountTypes.data:
+            if "session" not in self.state:
+                dataset = None
+                if "run" in self.state:
+                    dataset = self.gc.get(
+                        f"version/{self.state['run']['runVersionId']}/dataSet"
+                    )
+                else:
+                    dataset = self.state["tale"]["dataSet"]
+                if not dataset:
+                    return None, None
+                self.state["session"] = self.gc.post(
+                    "dm/session", parameters={"dataSet": json.dumps(dataset)}
+                )
+            return self.state["session"], "wt_dms"
+        elif mount_type == MountTypes.runs:
+            return self.state["tale"], "wt_runs"
+
+
+def main():
+    tornado.options.parse_command_line()
+    app = tornado.web.Application(handlers=[(r"/", MainHandler, {"state": mount})])
+    http_server = tornado.httpserver.HTTPServer(app)
+    http_server.listen(options.port)
+    tornado.ioloop.IOLoop.instance().start()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -3,59 +3,54 @@
 
 import os
 import sys
-
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 import girderfs
 
 
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist upload')
+if sys.argv[-1] == "publish":
+    os.system("python setup.py sdist upload")
     sys.exit()
 
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
+with open(os.path.join(os.path.dirname(__file__), "README.rst")) as f:
     readme = f.read()
 
 classifiers = [
-        'Development Status :: 3 - Alpha',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Topic :: System :: Filesystems'
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: System :: Filesystems",
 ]
 
-install_requires = ['fusepy', 'girder-client', 'requests', 'python-dateutil',
-                    'six']
-if sys.version_info[0] == 2:
-    install_requires.append('pathlib')
-    install_requires.append('backports.datetime_timestamp')
-    install_requires.append('future')
-
 setup(
-    name='girderfs',
+    name="girderfs",
     version=girderfs.__version__,
-    description='FUSE filesystem allowing to mount Girder\'s fs assetstore',
+    description="FUSE filesystem allowing to mount Girder's fs assetstore",
     long_description=readme,
-    packages=['girderfs'],
+    packages=["girderfs"],
     entry_points={
-        'console_scripts': [
-            'girderfs = girderfs.__main__:main'
+        "console_scripts": [
+            "girderfs = girderfs.__main__:main",
+            "girderfs-server = girderfs.server:main",
         ]
     },
-    install_requires=install_requires,
-    tests_require=['pytest'],
+    install_requires=[
+        "fusepy",
+        "girder-client",
+        "requests",
+        "python-dateutil",
+        "diskcache",
+    ],
+    tests_require=["pytest"],
     author=girderfs.__author__,
-    author_email='xarthisius.kk@gmail.com',
-    url='https://github.com/data-exp-lab/girder_fs',
-    license='BSD',
+    author_email="xarthisius.kk@gmail.com",
+    url="https://github.com/whole-tale/girderfs",
+    license="BSD",
     classifiers=classifiers,
 )


### PR DESCRIPTION
The gist of this PR is the addition of HTTP server, which as a service that can a) mount multiple fses based on JSON payload and b) unmount them.  Other notable points:
1. New dockerfile that runs HTTP server
2. Schema for payload is defined in `girderfs/schema.py`
3. Server itself mostly ports all the code related to volumes from gwvolman